### PR TITLE
Hacks to play nice with MC2

### DIFF
--- a/source/DangIt/Failure modules/FailureModule.cs
+++ b/source/DangIt/Failure modules/FailureModule.cs
@@ -501,7 +501,9 @@ namespace ippo
                 this.Log("Spare parts check: OK! Maintenance allowed allowed");
 
                 // Consume the spare parts
-                evaPart.RequestResource(Spares.Name, this.MaintenanceCost);
+                // MC2 Breaks RequestResource, since amount is checked, simply decrement! Just like in SparesContainer! Whee! -TrypChangeling
+                // evaPart.RequestResource(Spares.Name, this.MaintenanceCost);
+                evaPart.Resources[Spares.Name].amount -= this.MaintenanceCost;
 
                 // Compute the minimum distance between the kerbal's perks and the required perks
                 // The distance is used to scale the maintenance bonus according to the kerbal's skills
@@ -651,7 +653,9 @@ namespace ippo
 
                     this.Log("Kerbal's intelligence: " + intelligence + ", discount: " + discount);
 
-                    evaPart.RequestResource(Spares.Name, discountedCost);
+                    // One more MC2 hack - TrypChangeling
+                    // evaPart.RequestResource(Spares.Name, discountedCost);
+                    evaPart.Resources[Spares.Name].amount -= discountedCost;
                     ResourceDisplay.Instance.Refresh();
 
                     DangIt.Broadcast(this.RepairMessage, true);

--- a/source/DangIt/Maintenance/SparesContainer.cs
+++ b/source/DangIt/Maintenance/SparesContainer.cs
@@ -85,7 +85,9 @@ namespace ippo
 
             // Add it to the spares container and drain it from the EVA part
             container.RequestResource(Spares.Name, -deposit);
-            evaPart.RequestResource(Spares.Name, deposit);
+            // Once again, MC2 breaks the RequestResource on evaPart, but with the above checks, decrementing should work just fine instead, I think! -TrypChangeling
+            //evaPart.RequestResource(Spares.Name, deposit);
+            evaPart.Resources[Spares.Name].amount -= deposit;
 
             // GUI acknowledge
             try
@@ -116,6 +118,12 @@ namespace ippo
                 evaPart.Resources.Add(node);
             }
 
+            // Override maxAmount set by other mods (such as MC2) causing taking of parts to fail -TrypChangeling
+            if (evaPart.Resources[Spares.Name].maxAmount < Spares.MaxEvaAmount)
+            {
+            	evaPart.Resources[Spares.Name].maxAmount = Spares.MaxEvaAmount;
+            }
+
 
             // Compute how much the kerbal can take
             double desired = Spares.MaxEvaAmount - evaPart.Resources[Spares.Name].amount;
@@ -124,7 +132,9 @@ namespace ippo
 
             // Take it from the container and add it to the EVA
             container.RequestResource(Spares.Name, amountTaken);
-            evaPart.RequestResource(Spares.Name, -amountTaken);
+            // RequestResource is being overridden by MC2 for some reason - however, with above checks, simply incrementing the value should work... I think! - TrypChangeling
+            // evaPart.RequestResource(Spares.Name, -amountTaken);
+            evaPart.Resources[Spares.Name].amount += amountTaken;
 
             // GUI stuff
             DangIt.Broadcast(evaPart.vessel.GetVesselCrew().First().name + " has taken " + amountTaken + " spares", false, 1f);


### PR DESCRIPTION
Not using RequestResource any more; accessing resources directly - also
overriding the low limit for Spares.

I've been playing with this hack for just about a week alongside MC2 and not had any problems with either mod since. I'm not sure why RequestResource doesn't work but manipulating the resources directly do, but this has cleared up everything for me.