### PR TITLE
Fix costs of SpareParts containers to match current CRP value

### DIFF
--- a/source/DangIt/Data/ModuleManager/SpareParts.cfg
+++ b/source/DangIt/Data/ModuleManager/SpareParts.cfg
@@ -5,7 +5,7 @@
 
 @PART[*]:HAS[#CrewCapacity[1]]:FOR[DangIt]
 {
-	@cost += 3150
+	@cost += 630
     RESOURCE
 	{
 		name = SpareParts
@@ -20,7 +20,7 @@
 
 @PART[*]:HAS[#CrewCapacity[2]]:FOR[DangIt]
 {
-	@cost += 6300
+	@cost += 1260
     RESOURCE
 	{
 		name = SpareParts
@@ -35,7 +35,7 @@
 
 @PART[*]:HAS[#CrewCapacity[3]]:FOR[DangIt]
 {
-	@cost += 9450
+	@cost += 1890
     RESOURCE
 	{
 		name = SpareParts
@@ -50,7 +50,7 @@
 
 @PART[*]:HAS[#CrewCapacity[4]]:FOR[DangIt]
 {
-	@cost += 12600
+	@cost += 2520
     RESOURCE
 	{
 		name = SpareParts
@@ -65,7 +65,7 @@
 
 @PART[*]:HAS[#CrewCapacity[5]]:FOR[DangIt]
 {
-	@cost += 15750
+	@cost += 3150
     RESOURCE
 	{
 		name = SpareParts
@@ -80,7 +80,7 @@
 
 @PART[*]:HAS[#CrewCapacity[6]]:FOR[DangIt]
 {
-	@cost += 18900
+	@cost += 3780
     RESOURCE
 	{
 		name = SpareParts
@@ -95,7 +95,7 @@
 
 @PART[*]:HAS[#CrewCapacity[7]]:FOR[DangIt]
 {
-	@cost += 22050
+	@cost += 4410
     RESOURCE
 	{
 		name = SpareParts
@@ -110,7 +110,7 @@
 
 @PART[*]:HAS[#CrewCapacity[8]]:FOR[DangIt]
 {
-	@cost += 25200
+	@cost += 5040
     RESOURCE
 	{
 		name = SpareParts
@@ -125,7 +125,7 @@
 
 @PART[Mk1FuselageStructural]:FOR[DangIt]
 {
-	@cost += 9450
+	@cost += 1890
     RESOURCE
 	{
 		name = SpareParts


### PR DESCRIPTION
On [March 30](https://github.com/BobPalmer/CommunityResourcePack/commit/a3caffecb95d186f91ca40460529d27a887544a9) CRP reduced the cost of SpareParts by 5x from 63 per piece to 12.6 (I'm unfamiliar with the reason for the change).

However, the hardcoded cost increase for sparepart containers in SpareParts.cfg uses 63 * max no. of spareparts. Then, getting refunded for every sparepart you don't bring now yields you only 12.6.

The reason for discovery was "Why does 1 structural fuselage cost 9450 or 7560??" when trying to build a station.

Now imagine the horror upon realizing that for the bulk of my career I've been unwittingly paying +~2000 per kerbal on all of my manned flights for all the spare parts I didn't bring, and thinking that the high cost of command modules was simply due to the harsh economics of space exploration :frowning:. Dang it!